### PR TITLE
Remove header to make uploads work

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ impl Client {
         self.upload_inner(reader, |chunk, offset| {
             let mut headers = self.headers.clone();
             headers.insert(UPLOAD_OFFSET.clone(), HeaderValue::from_str(&format!("{}", offset))?);
+            headers.remove("upload-length");
             self.upload_chunk(chunk, headers)
         })
     }


### PR DESCRIPTION
I can't make the upload test work unless I explicitly remove the `upload-length` header. This PR just adds a line removing the offending header from the `HeaderMap`